### PR TITLE
possible fix for icmp bug

### DIFF
--- a/setup.yml
+++ b/setup.yml
@@ -127,7 +127,7 @@
     # ensure icmp from userspace applications works
     - lineinfile:
         dest: /etc/sysctl.conf
-        line: net.ipv4.ping_group_range="0   2147483647"
+        line: net.ipv4.ping_group_range=0   2147483647
       when: ansible_distribution == "Debian" or ansible_distribution == "Ubuntu"
 
     - lineinfile:


### PR DESCRIPTION
A quick look on an Ubuntu machine shows unhappiness with the quoted sysctl syntax for `net.ipv4.ping_group_range`. This change at least gets `sysctl -p` to accept the new value. This hopefully fixes the PING issue as well.... will test on a fresh testbed node soon.